### PR TITLE
Enhancement: Reference phpunit.xsd

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="bootstrap/autoload.php"
          colors="true"


### PR DESCRIPTION
This PR

* [x] references the XML schema for `phpunit.xml` as installed locally via `composer`

💁‍♂️ This has the advantage of providing auto-completion for `phpunit.xml` (at least in PhpStorm).